### PR TITLE
Use .env rather than config.yaml for local config settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+RACK_ENV=development
+APP_ID=appid
+APP_API_KEY=appapikey
+APP_SECRET=appsecret
+APP_CANVAS_NAME=appcanvasname

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 *.db
 *.sqlite3
 .bundle/*
-config.yaml
 .env

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'data_mapper'
 gem 'json'
 
 group :development, :test do
+  gem 'dotenv'
   gem 'dm-sqlite-adapter'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       data_objects (= 0.10.10)
     do_sqlite3 (0.10.10)
       data_objects (= 0.10.10)
+    dotenv (0.6.0)
     eventmachine (1.0.0)
     faraday (0.7.6)
       addressable (~> 2.2)
@@ -132,6 +133,7 @@ DEPENDENCIES
   data_mapper
   dm-postgres-adapter
   dm-sqlite-adapter
+  dotenv
   haml
   json
   mogli (~> 0.0.36)

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ Install dependencies:
 bundle install
 ```
 
-There are a few config settings required to run the app. When working locally, config settings are read from a config file `config.yaml` (which is obviously entered into `.gitignore`) and on Heroku, config settings are read from environment variables.
+There are a few config settings required to run the app which are stored in environment variables. When working locally, config settings are read from a `.env` file (which is obviously entered into `.gitignore`).
 
-Create a `config.yaml` file based on `config.example.yaml`:
+Create a `.env` file based on `.env.example`:
 
 ```
-cp config.example.yaml config.yaml
+cp .env.example .env
 ```
 
-Edit `config.yaml` to include the config settings found on the _Local Dev Campaign Monitor Subscribe_ [admin page](https://developers.facebook.com/apps/195059907238783). You might like to reference the config settings for the development app _devcmfbsub_ on Heroku:
+Edit `.env` to include the config settings found on the _Local Dev Campaign Monitor Subscribe_ [admin page](https://developers.facebook.com/apps/195059907238783). You might like to reference the config settings for the development app _devcmfbsub_ on Heroku:
 
 ```
 heroku config --app devcmfbsub

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,0 @@
-APP_ID: 'your_app_id'
-APP_API_KEY: 'your_app_api_key'
-APP_SECRET: 'your_app_secret'
-APP_CANVAS_NAME: 'your_canvas_name'

--- a/environment.rb
+++ b/environment.rb
@@ -5,13 +5,15 @@ require 'sass'
 require 'json'
 
 require 'sinatra' unless defined?(Sinatra)
-require "sinatra/reloader" if development?
-require 'yaml' if development?
+
+if development?
+  require 'sinatra/reloader'
+  require 'dotenv'
+  Dotenv.load
+end
 
 configure do
-  # load models
-  $LOAD_PATH.unshift("#{File.dirname(__FILE__)}/lib")
+  $LOAD_PATH.unshift("#{File.dirname(__FILE__)}/lib") # Load models
   Dir.glob("#{File.dirname(__FILE__)}/lib/*.rb") { |lib| require File.basename(lib, '.*') }
-
   DataMapper.setup(:default, (ENV["DATABASE_URL"] || "sqlite3:///#{File.expand_path(File.dirname(__FILE__))}/#{Sinatra::Base.environment}.db"))
 end


### PR DESCRIPTION
This is another small step to making the code cleaner and more ready for migration to Heroku Cedar.

When developing locally, config values are read into environment variables (accessed via `ENV` as usual in Ruby) from the `.env` file.

The README contains instructions for how to set up a development environment for this small change.
