### PR TITLE
Logging the session contents when redirecting away from the Facebook

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -349,6 +349,9 @@ end
 get '/auth/facebook/callback/?' do
   session['fb_auth'] = request.env['omniauth.auth']
   session['fb_token'] = session['fb_auth']['credentials']['token']
+  logger.info "Redirecting from Facebook callback..."
+  logger.info "Contents of session:"
+  logger.info session
   redirect '/'
 end
 


### PR DESCRIPTION
After reviewing the logs, it looks like between /auth/facebook/callback? and / the session becomes empty.  Curious to see what should have been put into the session but consequently was not.
