### PR TITLE
Use the most recent entry in the Form table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+sudo: false
+rvm:
+  - 2.1
+  - 2.0.0
+  - 1.9.3
+  - jruby-19mode

--- a/application.rb
+++ b/application.rb
@@ -110,7 +110,7 @@ def get_page(page_id)
 end
 
 def get_form_by_page_id(page_id)
-  Form.first(:page_id => page_id)
+  Form.first(:page_id => page_id, :order => [ :id.desc ])
 end
 
 def get_api_key(site_url, username, password)

--- a/application.rb
+++ b/application.rb
@@ -11,7 +11,7 @@ configure do
   set :views, "#{File.dirname(__FILE__)}/views"
   enable :sessions
   set :session_secret, ENV["APP_SECRET"]
-  DataMapper.setup(:default, (ENV["DATABASE_URL"] || "sqlite3:///#{File.expand_path(File.dirname(__FILE__))}/#{Sinatra::Base.environment}.db"))
+  DataMapper.setup(:default, (ENV["DATABASE_URL"] || "postgres://ruhbwztujwectk:9IApX5zJEe4Uhjnwp-9uGRqVWE@ec2-54-197-237-120.compute-1.amazonaws.com:5432/denssqf8sk6qch"))
 
   use Rack::Facebook, { :secret => ENV["APP_SECRET"] }
   use OmniAuth::Builder do


### PR DESCRIPTION
This prevents scenarios where a client switches to a new account but all subscribers are added to the first entry, which is no longer the account they want to use. Before this change a user could add the app to a Facebook page pointing to a list in one account, remove the list, then add the app again and point it to a different list in a different account. The entry we likely care about is the most recent entry.
